### PR TITLE
log stdout if an error is encountered for more info on what the issue is

### DIFF
--- a/src/commands/deleteTest.js
+++ b/src/commands/deleteTest.js
@@ -14,6 +14,7 @@ const deleteTest = async (name) => {
     }
   } catch (err) {
     spinner.fail(`Error deleting test: ${err}`);
+    if (err["stdout"]) console.log(err["stdout"]);
   }
 };
 

--- a/src/commands/destroy.js
+++ b/src/commands/destroy.js
@@ -9,6 +9,7 @@ const destroyEKSCluster = async () => {
     spinner.succeed("Deleted Edamame Cluster");
   } catch (err) {
     spinner.fail(`Error deleting cluster: ${err}`);
+    if (err["stdout"]) console.log(err["stdout"]);
   }
 };
 

--- a/src/commands/getTest.js
+++ b/src/commands/getTest.js
@@ -19,6 +19,7 @@ const getTest = async (name) => {
     }
   } catch (err) {
     spinner.fail(`Error retrieving test details: ${err}`);
+    if (err["stdout"]) console.log(err["stdout"]);
   }
 };
 

--- a/src/commands/getTests.js
+++ b/src/commands/getTests.js
@@ -19,6 +19,7 @@ const getTests = async () => {
     }
   } catch (err) {
     spinner.fail(`Error retrieving historical test information: ${err}`);
+    if (err["stdout"]) console.log(err["stdout"]);
   }
 };
 

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -28,7 +28,7 @@ const init = async () => {
     spinner.succeed("Cluster configured. Welcome to Edamame!");
   } catch (err) {
     spinner.fail(`Error creating cluster: ${err}`);
-    return;
+    if (err["stdout"]) console.log(err["stdout"]);
   }
 };
 

--- a/src/commands/portForwardGrafana.js
+++ b/src/commands/portForwardGrafana.js
@@ -21,8 +21,8 @@ const portForwardGrafana = async () => {
     spinner.fail(
       `Error port forwardng to Grafana: ${err.message}`
     );
+    if (err["stdout"]) console.log(err["stdout"]);
   }
-
 };
 
 const stopGrafana = async () => {

--- a/src/commands/runTest.js
+++ b/src/commands/runTest.js
@@ -64,6 +64,7 @@ const runTest = async (options) => {
     files.delete("testIsRunning.txt");
   } catch (err) {
     spinner.fail(`Error running test: ${err}`);
+    if (err["stdout"]) console.log(err["stdout"]);
   }
 };
 

--- a/src/commands/updateTestName.js
+++ b/src/commands/updateTestName.js
@@ -27,6 +27,7 @@ const updateTestName = async (options) => {
     }
   } catch (err) {
     spinner.fail(`Error updating the test name: ${err}`);
+    if (err["stdout"]) console.log(err["stdout"]);
   }
 };
 


### PR DESCRIPTION
Example:
Created a cluster and then temporarily commented out the check for an existing edamame cluster in cluster.js (to force an error on purpose) and tried to re-execute `edamame init`. Before this pr's update  to log `stdout` when an error was encountered, minimal error information was provided:
![beforeStdout](https://github.com/edamame-load-test/edamame/assets/76174119/5eaeb8c0-29eb-43b1-b8bf-ab254591bf71)

This update provides more info to the user about the issue:
![afterStdoutEdit](https://github.com/edamame-load-test/edamame/assets/76174119/9c5dfbdd-5c54-446e-8740-036a11f90751)
